### PR TITLE
Updated BUILD.gn for using clang on macOS

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -39,7 +39,6 @@ config("default") {
 
   if (is_win) {
     cflags += [
-      "/FS",  # Preserve previous PDB behavior.
       "/bigobj",  # Some of our files are bigger than the regular limits.
       "/WX",  # Treat warnings as errors.
       "/utf-8",  # Set Source and Executable character sets to UTF-8.
@@ -54,32 +53,18 @@ config("default") {
       "NOMINMAX",
     ]
 
-    _include_dirs = [
-      #2017
-      "$windk/VC/Tools/MSVC/14.10.25017/include",
-
-      #2015
-      "$windk/VC/include",
-
-      # For local builds.
-      # 2017
-      "$windk/../../../Windows Kits/10/Include/10.0.14393.0/shared",
-      "$windk/../../../Windows Kits/10/Include/10.0.14393.0/ucrt",
-      "$windk/../../../Windows Kits/10/Include/10.0.14393.0/um",
-      "$windk/../../../Windows Kits/10/Include/10.0.14393.0/winrt",
-
-      # 2015
-      "$windk/../Windows Kits/8.1/Include/shared",
-      "$windk/../Windows Kits/10/Include/10.0.10150.0/ucrt",
-      "$windk/../Windows Kits/8.1/Include/um",
-      "$windk/../Windows Kits/8.1/Include/winrt",
-
-      # For builds using win_toolchain asset.
-      "$windk/win_sdk/Include/10.0.14393.0/shared",
-      "$windk/win_sdk/Include/10.0.14393.0/ucrt",
-      "$windk/win_sdk/Include/10.0.14393.0/um",
-      "$windk/win_sdk/Include/10.0.14393.0/winrt",
+    if (msvc == 2015) {
+      _include_dirs = [ "$win_vc/include" ]
+    } else {  # 2017
+      _include_dirs = [ "$win_vc/Tools/MSVC/$win_toolchain_version/include" ]
+    }
+    _include_dirs += [
+      "$win_sdk/Include/$win_sdk_version/shared",
+      "$win_sdk/Include/$win_sdk_version/ucrt",
+      "$win_sdk/Include/$win_sdk_version/um",
+      "$win_sdk/Include/$win_sdk_version/winrt",
     ]
+
     if (is_clang) {
       foreach(dir, _include_dirs) {
         cflags += [
@@ -92,28 +77,18 @@ config("default") {
     }
 
     lib_dirs = [
-      # For local builds.
-      # 2017
-      "$windk/../../../Windows Kits/10/Lib/10.0.14393.0/ucrt/$target_cpu",
-      "$windk/../../../Windows Kits/10/Lib/10.0.14393.0/um/$target_cpu",
-
-      #2015
-      "$windk/../Windows Kits/10/Lib/10.0.10150.0/ucrt/$target_cpu",
-      "$windk/../Windows Kits/8.1/Lib/winv6.3/um/$target_cpu",
-
-      # For builds using win_toolchain asset.
-      "$windk/win_sdk/Lib/10.0.14393.0/ucrt/$target_cpu",
-      "$windk/win_sdk/Lib/10.0.14393.0/um/$target_cpu",
+      "$win_sdk/Lib/$win_sdk_version/ucrt/$target_cpu",
+      "$win_sdk/Lib/$win_sdk_version/um/$target_cpu",
     ]
-
-    #2017
-    lib_dirs += [ "$windk/VC/Tools/MSVC/14.10.25017/lib/$target_cpu" ]
-
-    #2015
-    if (target_cpu == "x86") {
-      lib_dirs += [ "$windk/VC/lib" ]
-    } else {
-      lib_dirs += [ "$windk/VC/lib/amd64" ]
+    if (msvc == 2015) {
+      if (target_cpu == "x86") {
+        lib_dirs += [ "$win_vc/lib" ]
+      } else {
+        lib_dirs += [ "$win_vc/lib/amd64" ]
+      }
+    } else {  # 2017
+      lib_dirs +=
+          [ "$win_vc/Tools/MSVC/$win_toolchain_version/lib/$target_cpu" ]
     }
   } else {
     cflags += [
@@ -137,11 +112,17 @@ config("default") {
       "-mfpu=neon",
       "-mthumb",
     ]
-  } else if (current_cpu == "mipsel") {
-    cflags += [ "-march=mips32r2" ]
+  } else if (current_cpu == "loongson3a") {
+    asmflags += [ "-march=loongson3a" ]
+    cflags += [
+      "-march=loongson3a",
+
+      # Causes an internal compiler error.
+      "-DSKCMS_PORTABLE",
+    ]
   } else if (current_cpu == "mips64el") {
-    asmflags += [ "-integrated-as" ]
-    cflags += [ "-integrated-as" ]
+    asmflags += [ "-march=mips64" ]
+    cflags += [ "-march=mips64" ]
   } else if (current_cpu == "x86" && !is_win) {
     asmflags += [ "-m32" ]
     cflags += [
@@ -171,9 +152,9 @@ config("default") {
       "--target=$ndk_target",
     ]
     cflags_cc += [
+      "-isystem$ndk/sources/cxx-stl/llvm-libc++/include",
+      "-isystem$ndk/sources/cxx-stl/llvm-libc++abi/include",
       "-isystem$ndk/sources/android/support/include",
-      "-isystem$ndk/sources/cxx-stl/gnu-libstdc++/4.9/include",
-      "-isystem$ndk/sources/cxx-stl/gnu-libstdc++/4.9/libs/$ndk_stdlib/include",
     ]
     ldflags += [
       "--sysroot=$ndk/platforms/$ndk_platform",
@@ -181,18 +162,15 @@ config("default") {
       "-B$ndk/toolchains/$ndk_gccdir-4.9/prebuilt/$ndk_host/$ndk_target/bin",
     ]
     lib_dirs = [
-      "$ndk/sources/cxx-stl/gnu-libstdc++/4.9/libs/$ndk_stdlib",
+      "$ndk/sources/cxx-stl/llvm-libc++/libs/$ndk_stdlib",
       "$ndk/toolchains/$ndk_gccdir-4.9/prebuilt/$ndk_host/lib/gcc/$ndk_target/4.9.x",
     ]
 
-    if (current_cpu == "mips64el") {
-      # The r15b NDK deployed on our bots fails to find /usr/lib64 in  the
-      # MIPS64 sysroots, so we must point Clang at /usr/lib64 manually.
-      lib_dirs += [ "$ndk/platforms/$ndk_platform/usr/lib64" ]
-      ldflags += [ "-B$ndk/platforms/$ndk_platform/usr/lib64" ]
-    }
-
-    libs += [ "gnustl_static" ]
+    libs += [
+      "c++_static",
+      "c++abi",
+      "android_support",
+    ]
   }
 
   if (is_ios) {
@@ -230,13 +208,53 @@ config("default") {
   if (is_linux) {
     libs += [ "pthread" ]
   }
+  if (is_mac) {
+    # Disable linker warnings.  They're usually just annoyances like,
+    #   ld: warning: text-based stub file
+    #     /System/Library/Frameworks/foo.framework/foo.tbd and library file
+    #     /System/Library/Frameworks/foo.framework/foo are out of sync.
+    #     Falling back to library file for linking.
+    ldflags += [ "-Wl,-w" ]
+  }
 
   if (sanitize != "") {
     # You can either pass the sanitizers directly, e.g. "address,undefined",
     # or pass one of the couple common aliases used by the bots.
     sanitizers = sanitize
-    if (sanitize == "ASAN") {
-      sanitizers = "address,bool,function,integer-divide-by-zero,nonnull-attribute,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr"
+
+    # fyi_sanitizers only print out stacktraces of their issues
+    fyi_sanitizers = fyi_sanitize
+    if (sanitize == "ASAN" || sanitize == "UBSAN") {
+      # ASAN implicitly runs all UBSAN checks also.
+      sanitizers = "bool,float-cast-overflow,integer-divide-by-zero,nonnull-attribute,null,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound"
+
+      if (fyi_sanitize == "" && !is_android) {
+        fyi_sanitizers = "float-divide-by-zero"
+      }
+
+      if (!is_mac && !is_win) {
+        sanitizers += ",function"  # Not supported on Mac or Win.
+      }
+      if (!is_win) {
+        sanitizers += ",vptr"  # Not supported on Win.
+      }
+      if (!is_debug && !is_win) {
+        # No-op with somewhat annoying warning at -O0.
+        # Seems to be broken on Win.
+        sanitizers += ",object-size"
+      }
+      if (sanitize == "ASAN") {
+        sanitizers += ",address"
+      }
+      if (is_android) {
+        # Android only easily supports address for now
+        # UBSAN runs into linking errors
+        sanitizers = "address"
+
+        # recommended by
+        # https://github.com/google/sanitizers/wiki/AddressSanitizerOnAndroid
+        cflags += [ "-fno-omit-frame-pointer" ]
+      }
     } else if (sanitize == "TSAN") {
       sanitizers = "thread"
     } else if (sanitize == "MSAN") {
@@ -244,15 +262,19 @@ config("default") {
     }
 
     cflags += [
-      "-fsanitize=$sanitizers",
+      "-fsanitize=$sanitizers,$fyi_sanitizers",
       "-fno-sanitize-recover=$sanitizers",
-      "-fsanitize-blacklist=" + rebase_path("../tools/xsan.blacklist"),
     ]
+    if (!is_win) {
+      cflags += [ "-fno-omit-frame-pointer" ]
+    }
+    if (is_linux) {
+      cflags_cc += [ "-stdlib=libc++" ]
+      ldflags += [ "-stdlib=libc++" ]
+    }
     ldflags += [ "-fsanitize=$sanitizers" ]
     if (sanitizers == "memory") {
       cflags += [ "-fsanitize-memory-track-origins" ]
-      cflags_cc += [ "-stdlib=libc++" ]
-      ldflags += [ "-stdlib=libc++" ]
     }
   }
 }
@@ -294,83 +316,101 @@ config("warnings") {
       "-Wno-deprecated-declarations",
       "-Wno-maybe-uninitialized",
     ]
-    cflags_cc += [ "-Wnon-virtual-dtor" ]
+    cflags_cc += [
+      "-Wnon-virtual-dtor",
+      "-Wno-noexcept-type",
+    ]
+  }
 
-    if (is_clang) {
-      cflags += [
-        "-Weverything",
-        "-Wno-unknown-warning-option",  # Let older Clangs ignore newer Clangs' warnings.
-      ]
+  if (is_clang) {
+    cflags += [
+      "-Weverything",
+      "-Wno-unknown-warning-option",  # Let older Clangs ignore newer Clangs' warnings.
+    ]
 
-      if ((target_cpu == "x86" && is_android) ||
-          (target_cpu == "arm" && is_ios)) {
-        # Clang seems to think new/malloc will only be 4-byte aligned on x86 Android and 32-bit iOS.
-        # We're pretty sure it's actually 8-byte alignment.
-        cflags += [ "-Wno-over-aligned" ]
-      }
-
-      cflags += [
-        "-Wno-cast-align",
-        "-Wno-conditional-uninitialized",
-        "-Wno-conversion",
-        "-Wno-disabled-macro-expansion",
-        "-Wno-documentation",
-        "-Wno-documentation-unknown-command",
-        "-Wno-double-promotion",
-        "-Wno-exit-time-destructors",  # TODO: OK outside libskia
-        "-Wno-float-conversion",
-        "-Wno-float-equal",
-        "-Wno-format-nonliteral",
-        "-Wno-global-constructors",  # TODO: OK outside libskia
-        "-Wno-gnu-zero-variadic-macro-arguments",
-        "-Wno-missing-prototypes",
-        "-Wno-missing-variable-declarations",
-        "-Wno-pedantic",
-        "-Wno-reserved-id-macro",
-        "-Wno-shadow",
-        "-Wno-shift-sign-overflow",
-        "-Wno-sign-conversion",
-        "-Wno-signed-enum-bitfield",
-        "-Wno-switch-enum",
-        "-Wno-undef",
-        "-Wno-unreachable-code",
-        "-Wno-unreachable-code-break",
-        "-Wno-unreachable-code-return",
-        "-Wno-unused-macros",
-        "-Wno-unused-member-function",
-      ]
-      cflags_cc += [
-        "-Wno-abstract-vbase-init",
-        "-Wno-weak-vtables",
-      ]
-
-      # We are unlikely to want to fix these.
-      cflags += [
-        "-Wno-covered-switch-default",
-        "-Wno-deprecated",
-        "-Wno-implicit-fallthrough",
-        "-Wno-missing-noreturn",
-        "-Wno-old-style-cast",
-        "-Wno-padded",
-      ]
-      cflags_cc += [
-        "-Wno-c++98-compat",
-        "-Wno-c++98-compat-pedantic",
-        "-Wno-undefined-func-template",
-      ]
-      cflags_objc += [
-        "-Wno-direct-ivar-access",
-        "-Wno-objc-interface-ivars",
-      ]
-      cflags_objcc += [
-        "-Wno-direct-ivar-access",
-        "-Wno-objcc-interface-ivars",
-      ]
+    if (target_cpu == "arm" && is_ios) {
+      # Clang seems to think new/malloc will only be 4-byte aligned on 32-bit iOS.
+      # We're pretty sure it's actually 8-byte alignment.
+      cflags += [ "-Wno-over-aligned" ]
     }
+    if (target_cpu == "x86" && is_android) {
+      # Clang seems to think new/malloc will only be 4-byte aligned on 32-bit x86 Android builds.
+      # We're pretty sure it's actually 8-byte alignment.  See OverAlignedTest.cpp for more info.
+      cflags += [ "-Wno-over-aligned" ]
+    }
+
+    # Shouldn't be necessary for local builds. With distributed Windows builds, files may lose
+    # their case during copy, causing case-sensitivity mismatch on remote machines.
+    cflags += [
+      "-Wno-nonportable-include-path",
+      "-Wno-nonportable-system-include-path",
+    ]
+
+    # TODO: These would all be really great warnings to turn on.
+    cflags += [
+      "-Wno-cast-align",
+      "-Wno-cast-qual",
+      "-Wno-conversion",
+      "-Wno-disabled-macro-expansion",
+      "-Wno-documentation",
+      "-Wno-documentation-unknown-command",
+      "-Wno-double-promotion",
+      "-Wno-exit-time-destructors",  # TODO: OK outside libskia
+      "-Wno-float-equal",
+      "-Wno-format-nonliteral",
+      "-Wno-global-constructors",  # TODO: OK outside libskia
+      "-Wno-missing-prototypes",
+      "-Wno-missing-variable-declarations",
+      "-Wno-pedantic",
+      "-Wno-reserved-id-macro",
+      "-Wno-shadow",
+      "-Wno-shift-sign-overflow",
+      "-Wno-signed-enum-bitfield",
+      "-Wno-switch-enum",
+      "-Wno-undef",
+      "-Wno-unreachable-code",
+      "-Wno-unreachable-code-break",
+      "-Wno-unreachable-code-return",
+      "-Wno-unused-macros",
+      "-Wno-unused-member-function",
+      "-Wno-unused-template",
+      "-Wno-zero-as-null-pointer-constant",
+      "-Wno-conditional-uninitialized",
+    ]
+    cflags_cc += [
+      "-Wno-abstract-vbase-init",
+      "-Wno-weak-vtables",
+    ]
+
+    # We are unlikely to want to fix these.
+    cflags += [
+      "-Wno-covered-switch-default",
+      "-Wno-deprecated",
+      "-Wno-missing-noreturn",
+      "-Wno-old-style-cast",
+      "-Wno-padded",
+      "-Wno-newline-eof",
+    ]
+    cflags_cc += [
+      "-Wno-c++98-compat",
+      "-Wno-c++98-compat-pedantic",
+      "-Wno-undefined-func-template",
+    ]
+    cflags_objc += [
+      "-Wno-direct-ivar-access",
+      "-Wno-objc-interface-ivars",
+    ]
+    cflags_objcc += [
+      "-Wno-direct-ivar-access",
+      "-Wno-objcc-interface-ivars",
+    ]
+  }
+  if (!is_win || is_clang) {
+    cflags += [ "-Wno-implicit-fallthrough" ]
   }
 }
 config("warnings_except_public_headers") {
-  if (!is_win) {
+  if (!is_win || is_clang) {
     cflags = [ "-Wno-unused-parameter" ]
   }
 }
@@ -392,8 +432,8 @@ config("debug_symbols") {
       "-funwind-tables",  # Helps make in-process backtraces fuller.
     ]
   } else if (is_win) {
-    cflags = [ "/Zi" ]
-    ldflags = [ "/DEBUG" ]
+    cflags = [ "/Z7" ]
+    ldflags = [ "/DEBUG:FASTLINK" ]
   } else {
     cflags = [ "-g" ]
   }
@@ -414,7 +454,6 @@ config("release") {
     cflags = [
       "/O2",
       "/Zc:inline",
-      "/GS-",
     ]
     ldflags = [
       "/OPT:ICF",
@@ -430,6 +469,13 @@ config("release") {
       ldflags = [ "-dead_strip" ]
     } else {
       ldflags = [ "-Wl,--gc-sections" ]
+    }
+    if (target_cpu == "wasm") {
+      # The compiler asks us to add an optimization flag to both cflags
+      # and ldflags to cut down on the local variables,
+      # for performance reasons.
+      # The "linking" step is the conversion to javascript.
+      ldflags += [ "-O3" ]
     }
   }
   defines = [ "NDEBUG" ]


### PR DESCRIPTION
Used BUILD.gn from the latest commit on google/skia. Otherwise I couldn't build skia on branch aseprite-m62. Tested only on macOS, not on Windows or Linux, but it should work on those too.