### PR TITLE
add missing dependencies to install_dependencies.sh

### DIFF
--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -34,6 +34,8 @@ if command -v lsb_release > /dev/null ; then
 		libglu1-mesa-dev
 		libpng-dev
 		libqt4-dev
+		libjpeg-dev
+		libwebp-dev
 		EOF
             )
            if [ $(lsb_release -r -s) = '14.04' ] ; then


### PR DESCRIPTION
These libraries are required to build, but are not included in the script for installation.