### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Download
 and uncompress it in some place like `C:\deps\depot_tools`.
 
 [It's recommended to compile Skia with Clang](https://github.com/google/skia/blob/master/site/user/build.md#a-note-on-software-backend-performance)
-to get better performance. So you will need to [download Clang](http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe),
+to get better performance. So you will need to [download Clang](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe),
 and install it on a folder like `C:\deps\llvm` (a folder without whitespaces).
 
 Open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
@@ -68,6 +68,7 @@ Finally, if you've downloaded Clang, use this command:
 
     set PATH=C:\deps\llvm\bin;%PATH%
     gn gen out/Release-x64 --args="is_debug=false is_official_build=true skia_use_system_expat=false skia_use_system_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false skia_use_sfntly=false skia_use_freetype=true skia_use_harfbuzz=true skia_pdf_subset_harfbuzz=true skia_use_system_freetype2=false skia_use_system_harfbuzz=false target_cpu=""x64"" cc=""clang"" cxx=""clang++"" clang_win=""c:\deps\llvm"" win_vc=""C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"" extra_cflags=[""-MT""]"
+    set PATH=C:\deps\depot_tools\bootstrap-3_8_0_chromium_8_bin\python\bin;%PATH%
     ninja -C out/Release-x64 skia modules
 
 If you haven't installed Clang, and want to compile Skia with MSVC


### PR DESCRIPTION
Updated clang's download link.
Added an additional step before running ninja to set the PATH to python's binary to avoid [a problem when compiling skia](https://community.aseprite.org/t/problem-compiling-skia/5945).