### PR TITLE
Fixed return error 127

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,1 +1,2 @@
 buildconfig = "//gn/BUILDCONFIG.gn"
+script_executable = "python2"


### PR DESCRIPTION
Generating ninja files would fail due `exec_script` defaulting to regular `python` command. This commit fixes the issue by uses the `python2` command instead.

**Error message:**
```
ERROR at //gn/BUILDCONFIG.gn:85:14: Script returned non-zero exit code.
  is_clang = exec_script("//gn/is_clang.py",
             ^----------
Current dir: /home/k105la-storage/deps/skia/out/Release-x64/
Command: python /home/k105la-storage/deps/skia/gn/is_clang.py cc c++
Returned 127.
```


