### PR TITLE
Force gn to use python 2.7

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,1 +1,2 @@
 buildconfig = "//gn/BUILDCONFIG.gn"
+script_executable = "vpython"


### PR DESCRIPTION
vpython is 2.7 and it is defined in chromium depot_tools