### PR TITLE
Update README.md with the 64-bit compilation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ and uncompress it in some place like `C:\deps\depot_tools`.
 to get better performance. So you will need to [download Clang](https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64.exe),
 and install it on a folder like `C:\deps\llvm` (a folder without whitespaces).
 
-Open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
-or command line (`cmd.exe`) and call:
+Open a command prompt window (`cmd.exe`) and call:
 
     call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=x64
+
+The command above is required while attempting to compile the 64-bit version of skia. When compiling the 32-bit version, it is possible to open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs) instead.
 
 Then:
 


### PR DESCRIPTION
Basically copied from the Aseprite readme. I have already accepted aseprite agreement and stuff, if I need to do that. It is a pretty simple change, hopefully can be added quickly.