### PR TITLE
Update clang_win_version regex to work with latest versions

### DIFF
--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -155,7 +155,7 @@ if (target_os == "win") {
     clang_win_version = exec_script("//gn/highest_version_dir.py",
                                     [
                                       "$clang_win/lib/clang",
-                                      "[0-9]+\.[0-9]+\.[0-9]+",
+                                      "[0-9]+(\.[0-9]+)?(\.[0-9]+)?",
                                     ],
                                     "trim string")
   }


### PR DESCRIPTION
This allows usage of latest clang kits like 18 where there is no directory that uses the x.y.z notation, only x.