### PR TITLE
Added a command for macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ several minutes to finish:
     cd skia
     python3 tools/git-sync-deps
     python3 bin/fetch-ninja
+    update_depot_tools
     gn gen out/Release-x64 --args="is_debug=false is_official_build=true skia_use_system_expat=false skia_use_system_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false skia_use_freetype=true skia_use_harfbuzz=true skia_pdf_subset_harfbuzz=true skia_use_system_freetype2=false skia_use_system_harfbuzz=false target_cpu=\"x64\" extra_cflags=[\"-stdlib=libc++\", \"-mmacosx-version-min=10.9\"] extra_cflags_cc=[\"-frtti\"]"
     ninja -C out/Release-x64 skia modules
 


### PR DESCRIPTION
I had to run "update_depot_tools" to initialize depot_tools, as said in a error message when running the "gn" command.

System : macOS 14.4.1
Arch : ARM64 (M2)

Maybe the init of depot tools is only needed on ARM64.